### PR TITLE
Stick Correct Drupal Core version, stick `php:7.1` and remove unaplicable patches

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: 'app'
 
 # The runtime the application uses.
-type: 'php:7.0'
+type: 'php:7.1'
 
 # Configuration of the build of this application.
 build:

--- a/composer.json
+++ b/composer.json
@@ -86,12 +86,6 @@
             "drush/contrib/{$name}": [
                 "type:drupal-drush"
             ]
-        },
-        "patches": {
-            "drupal/core": {
-                "Redirect to install.php on empty DB": "https://www.drupal.org/files/issues/728702-163.patch",
-                "Allow read-only config directories": "https://www.drupal.org/files/issues/drupal-2607352-6.patch"
-            }
         }
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "composer/installers": "^1.2",
         "drupal-composer/drupal-scaffold": "^2.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal/core": "~8.2.0",
+        "drupal/core": "~8.0",
         "drush/drush": "~8.0",
         "drupal/console": "~1.0",
         "drupal/commerce": "2.x-dev",


### PR DESCRIPTION
The `~8.2.0` triggers the following issue `Your requirements could not be resolved to an installable set of packages.`